### PR TITLE
Fix tcp timeout

### DIFF
--- a/Backend/src/routes/api.js
+++ b/Backend/src/routes/api.js
@@ -52,44 +52,16 @@ function openSocket() {
   var client = net.connect(CAR_PORT, CAR_ADDRESS);
   client.setKeepAlive(true);
 
+  // Set a timeout for the connection due to inactivity
   client.setTimeout(5000, () => {
-
-    if(solarCarData.solar_car_connection[0]) {
-      // Pull the most recent solar_car_connection values to false if connection was previously established
-      if (solarCarData.solar_car_connection.length > 0) {
-        solarCarData.solar_car_connection[0] = false;
-        frontendData.solar_car_connection[0] = false;
-      }
-
-      // Kill socket
-      client.destroy();
-      client.unref();
-
-      console.log(`Connection to car server (${CAR_PORT}) is closed - TIMEOUT`);
-
-      // Attempt to re-open socket
-      //setTimeout(openSocket, 1000);
-    }
-
+    // Emit a close event to close the connection on our end
+    client.emit("close");
   })
 
   // Connection established listener
   client.on("connect", () => {
     console.log(`Connected to car server: ${client.remoteAddress}:${CAR_PORT}`);
   });
-
-
-  // Data received listener
-  /*client.on("end", (data) => {
-    // console.log(data);
-    console.log("LOST THE CONNECTION ----------------------------------------------------------------------------------------------------------------------------------------------------");
-  });
-
-  // Data received listener
-  client.on("drain", (data) => {
-    // console.log(data);
-    console.log("DRAIN");
-  });*/
 
   // Data received listener
   client.on("data", (data) => {
@@ -100,32 +72,12 @@ function openSocket() {
   });
 
   // Socket closed listener
-  /*client.on("timeout", function () {
+  client.once("close", function () {
     // Pull the most recent solar_car_connection values to false if connection was previously established
     if (solarCarData.solar_car_connection.length > 0) {
       solarCarData.solar_car_connection[0] = false;
       frontendData.solar_car_connection[0] = false;
     }
-
-
-    // Kill socket
-    client.destroy();
-    client.unref();
-
-    console.log(`Connection to car server (${CAR_PORT}) is closed - TIMEOUT`);
-
-    // Attempt to re-open socket
-    setTimeout(openSocket, 1000);
-  });*/
-
-  // Socket closed listener
-  client.on("close", function () {
-    // Pull the most recent solar_car_connection values to false if connection was previously established
-    if (solarCarData.solar_car_connection.length > 0) {
-      solarCarData.solar_car_connection[0] = false;
-      frontendData.solar_car_connection[0] = false;
-    }
-
 
     // Kill socket
     client.destroy();
@@ -138,10 +90,11 @@ function openSocket() {
   });
 
   // Socket error listener
-  client.on("error", (err) => {
+  client.once("error", (err) => {
     // Log error
     console.log("Client errored out:", err);
 
+    /*
     // Kill socket
     //client.destroy();
     //client.unref();
@@ -150,7 +103,7 @@ function openSocket() {
     if (solarCarData.solar_car_connection.length > 0) {
       solarCarData.solar_car_connection[0] = false;
       frontendData.solar_car_connection[0] = false;
-    }
+    }*/
 
     // Attempt to re-open socket
     //setTimeout(openSocket, 1000);

--- a/Backend/src/routes/api.js
+++ b/Backend/src/routes/api.js
@@ -49,13 +49,47 @@ const X_AXIS_CAP = CONSTANTS.X_AXIS_CAP;
 function openSocket() {
   // Establish connection with server
   console.log('CAR_PORT: ' + CAR_PORT);
-  var client = net.connect(CAR_PORT, CAR_ADDRESS); // TODO Add third parameter (timeout in ms) if we want to timeout due to inactivity
+  var client = net.connect(CAR_PORT, CAR_ADDRESS);
   client.setKeepAlive(true);
+
+  client.setTimeout(5000, () => {
+
+    if(solarCarData.solar_car_connection[0]) {
+      // Pull the most recent solar_car_connection values to false if connection was previously established
+      if (solarCarData.solar_car_connection.length > 0) {
+        solarCarData.solar_car_connection[0] = false;
+        frontendData.solar_car_connection[0] = false;
+      }
+
+      // Kill socket
+      client.destroy();
+      client.unref();
+
+      console.log(`Connection to car server (${CAR_PORT}) is closed - TIMEOUT`);
+
+      // Attempt to re-open socket
+      //setTimeout(openSocket, 1000);
+    }
+
+  })
 
   // Connection established listener
   client.on("connect", () => {
     console.log(`Connected to car server: ${client.remoteAddress}:${CAR_PORT}`);
   });
+
+
+  // Data received listener
+  /*client.on("end", (data) => {
+    // console.log(data);
+    console.log("LOST THE CONNECTION ----------------------------------------------------------------------------------------------------------------------------------------------------");
+  });
+
+  // Data received listener
+  client.on("drain", (data) => {
+    // console.log(data);
+    console.log("DRAIN");
+  });*/
 
   // Data received listener
   client.on("data", (data) => {
@@ -66,6 +100,25 @@ function openSocket() {
   });
 
   // Socket closed listener
+  /*client.on("timeout", function () {
+    // Pull the most recent solar_car_connection values to false if connection was previously established
+    if (solarCarData.solar_car_connection.length > 0) {
+      solarCarData.solar_car_connection[0] = false;
+      frontendData.solar_car_connection[0] = false;
+    }
+
+
+    // Kill socket
+    client.destroy();
+    client.unref();
+
+    console.log(`Connection to car server (${CAR_PORT}) is closed - TIMEOUT`);
+
+    // Attempt to re-open socket
+    setTimeout(openSocket, 1000);
+  });*/
+
+  // Socket closed listener
   client.on("close", function () {
     // Pull the most recent solar_car_connection values to false if connection was previously established
     if (solarCarData.solar_car_connection.length > 0) {
@@ -73,7 +126,15 @@ function openSocket() {
       frontendData.solar_car_connection[0] = false;
     }
 
+
+    // Kill socket
+    client.destroy();
+    client.unref();
+
     console.log(`Connection to car server (${CAR_PORT}) is closed`);
+
+    // Attempt to re-open socket
+    setTimeout(openSocket, 1000);
   });
 
   // Socket error listener
@@ -82,8 +143,8 @@ function openSocket() {
     console.log("Client errored out:", err);
 
     // Kill socket
-    client.destroy();
-    client.unref();
+    //client.destroy();
+    //client.unref();
 
     // Pull the most recent solar_car_connection values to false if connection was previously established
     if (solarCarData.solar_car_connection.length > 0) {
@@ -92,7 +153,7 @@ function openSocket() {
     }
 
     // Attempt to re-open socket
-    setTimeout(openSocket, 1000);
+    //setTimeout(openSocket, 1000);
   });
 }
 


### PR DESCRIPTION
### Problem
Previously, lost connections between the dashboards were only tested by killing one of the dashboard programs, which caused the TCP socket to error out and break. Since the dashboards check for a lost connection when the socket errors/closes, the running dashboard would correctly detect that its connection to the other dashboard was lost. However, when simulating a lost connection by unplugging one of the radios from the pi/laptop, which is a better way to simulate lost connections than killing a dashboard, the TCP socket is not broken. Instead, it becomes stale, and neither dashboard realizes that its connection to the other has been lost because the socket did not close or error out.

### Solution
To solve the issue of not detecting stale/lost connections on the engineering dashboard's end, a timeout was added. After a certain period of inactivity, the timeout will be triggered and close the socket. Then, the dashboard will attempt to reconnect to the driver dashboard at fixed intervals (reconnecting was already a feature).