### PR TITLE
add RangeRow component

### DIFF
--- a/Frontend/src/Components/Shared/RangeRow.js
+++ b/Frontend/src/Components/Shared/RangeRow.js
@@ -1,0 +1,65 @@
+import {Flex, Center, Text, Spacer, useColorMode} from "@chakra-ui/react";
+import getColor from "../Shared/colors";
+import RangeBar from "./RangeBar";
+
+export default function RangeRow(props) {
+    const { colorMode } = useColorMode();
+    const borderColor = getColor("border", colorMode);
+
+    const bg = (props.dataValue < props.dataConstant.MIN || props.dataValue > props.dataConstant.MAX) ?
+        getColor("errorBg", colorMode) : props.bg;
+
+    // set the decimal point to 3 by default
+    const decPoint = props.DecimalPoint ?? 3;
+    
+    let lineHeight;
+    let textSize;
+    let rangeBarHeight;
+    if ((props.size ?? 'sm') === 'sm') {
+        lineHeight = '1.2em';
+        textSize = 'sm';
+        rangeBarHeight = '1em';
+    } else if (props.size === 'md') {
+        lineHeight = '1.6em';
+        textSize = 'md';
+        rangeBarHeight = '1.4em';
+    } else if (props.size === 'lg') {
+        lineHeight = '2em';
+        textSize = 'lg';
+        rangeBarHeight = '1.8em';
+    }
+
+    return (
+        <Center
+            borderTopWidth={1}
+            borderBottomWidth={props.borderBottomWidth ?? 1}
+            borderColor={borderColor}
+            bg={bg}
+            lineHeight={lineHeight}
+            height='100%'
+        >
+            <Flex w='95%'>
+                <Text fontSize={textSize}>{props.dataTitle}:</Text>
+                <Spacer />
+                <Text fontSize={textSize} paddingRight='0.5em'>
+                    {props.dataValue.toFixed(decPoint)} {props.dataConstant.UNIT}
+                </Text>
+
+                {/* Hold the RangeBar within a vertical Flex to vertically center it */}
+                <Flex direction='column'>
+                    <Spacer />
+                    <RangeBar 
+                        w={props.rangeBarW ?? '3em'} 
+                        h={rangeBarHeight}
+                        borderRadius='0px' 
+
+                        val={props.dataValue}
+                        min={props.dataConstant.MIN}
+                        max={props.dataConstant.MAX}
+                    />
+                    <Spacer />
+                </Flex>
+            </Flex>
+        </Center>
+    );
+}


### PR DESCRIPTION
## Progress on requirements: 
### Requirements:
- [x] The row’s height should automatically fit its container like DataPack does.
- [x] The RangeBar should have a width that can be passed as a prop to the generic row component. Also, its height should either be a fraction of the row’s height (preferred) or have a fixed vertical padding.
  - I can't seem to pass a percentage to the `h` prop from RangeBar—any idea why that might be? Right now I have it hardcoded to 1em instead.  
- [x] Aside from the props mentioned in other bullet points, the row component should only take in a label/title, a signal name, an optional precision (default is 3 decimal places), and an optional background color. The value, units, min, and max can be determined using the signal name. Don’t worry about the outliers like fan speed, pack power out, and pack temperature in BatteryPack.js. These won’t be issues anymore.
- [x] The text size/line height should be adjustable via an optional prop passed to the generic row component, or it could be automatically resized according to the nice-to-have below.
  - Do you think a small/medium/large would be appropriate here? I could then use a conditional to map the different size options into text sizes and row heights. How were you thinking this would work?
    - This is how I ended up doing it as of 4/13—it's definitely serviceable and works with the Chakra UI text size scheme that already exists

### Nice-to-haves:
- [x] If the text size could be adjusted to automatically fit the height of the row component, that would be very nice, but don’t let it block the task.

## Screenshots
4/14 vertically centered:
<img width="260" alt="image" src="https://user-images.githubusercontent.com/17338790/232172687-301b779b-0357-4609-8d18-4b9448645ac0.png">


4/14:
<img width="343" alt="image" src="https://user-images.githubusercontent.com/17338790/232171357-99382df5-2c5d-4df0-bc62-cb48dc7d8743.png">


4/12:
![image](https://user-images.githubusercontent.com/17338790/231629693-bb91df33-d050-4842-88b8-1a9043fec9b9.png)
