### PR TITLE
[SW-365] Add null data checks

### DIFF
--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chase-car-dashboard-backend",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chase-car-dashboard-backend",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chase-car-dashboard-backend",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "main": "src/server.js",
   "scripts": {

--- a/Backend/src/routes/api.js
+++ b/Backend/src/routes/api.js
@@ -27,7 +27,12 @@ for (const property in DATA_FORMAT) {
 // Send graph data to front-end
 ROUTER.get(CONSTANTS.ROUTES.GET_GRAPH_DATA, (req, res) => {
   //console.time("send http");
-  let final_data = filterGraphsToSend();
+  let final_data;
+  if (Object.keys(frontendData).length !== 0) {
+    final_data = filterGraphsToSend();
+  } else {
+    final_data = null;
+  }
   const temp = res.send({ response: final_data }).status(200);
   //temp.addListener("finish", () => console.timeEnd("send http"));
 });
@@ -36,7 +41,12 @@ ROUTER.get(CONSTANTS.ROUTES.GET_GRAPH_DATA, (req, res) => {
 // Send single values to front-end
 ROUTER.get(CONSTANTS.ROUTES.GET_SINGLE_VALUES, (req, res) => {
   // console.time("send http");
-  let singleValuesJSON = getSingleValues(frontendData);
+  let singleValuesJSON;
+  if (Object.keys(frontendData).length !== 0) { 
+    singleValuesJSON = getSingleValues(frontendData);
+  } else {
+    singleValuesJSON = null;
+  }
   // const temp =
   res.send({ response: singleValuesJSON }).status(200);
   // temp.addListener("finish", () => console.timeEnd("send http"));

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chase-car-dashboard-frontend",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chase-car-dashboard-frontend",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "dependencies": {
         "@chakra-ui/icons": "^1.1.5",
         "@chakra-ui/react": "^1.8.3",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chase-car-dashboard-frontend",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "proxy": "http://localhost:4001",
   "dependencies": {

--- a/Frontend/src/Components/Dashboard/Dashboard.js
+++ b/Frontend/src/Components/Dashboard/Dashboard.js
@@ -20,6 +20,7 @@ import DataRecordingControl from "./DataRecordingControl";
 import dvOptions from "./dataViewOptions";
 import getColor from "../Shared/colors";
 import { ROUTES } from "../Shared/misc-constants";
+import fauxQueue from "../Graph/faux-queue.json";
 
 // prevent accidental reloading/closing
 window.onbeforeunload = () => true;
@@ -57,19 +58,20 @@ function reducer([currentQueue], newData) {
  * @returns the JSON response from the graph data API
  */
 async function callBackendGraphDataAPI() {
-  console.time("graph data http call");
+  // console.time("graph data http call");
 
   const response = await fetch(ROUTES.GET_GRAPH_DATA);
-  console.timeLog("graph data http call", "fetch finished");
+  // console.timeLog("graph data http call", "fetch finished");
+  
   const body = await response.json();
-  console.timeLog("graph data http call", "json extracted");
+  // console.timeLog("graph data http call", "json extracted");
 
   if (response.status !== 200) {
     console.error("graph data api: error");
     throw Error(body.message);
   }
-
-  console.timeEnd("graph data http call");
+  
+  // console.timeEnd("graph data http call");
   // console.log("body", body);
   return body;
 }
@@ -79,19 +81,19 @@ async function callBackendGraphDataAPI() {
  * @returns the JSON response from the single values API
  */
 async function callBackendSingleValuesAPI() {
-  console.time("http call");
+  // console.time("single values http call");
 
   const response = await fetch(ROUTES.GET_SINGLE_VALUES);
-  console.timeLog("single values http call", "fetch finished");
+  // console.timeLog("single values http call", "fetch finished");
   const body = await response.json();
-  console.timeLog("single values http call", "json extracted");
+  // console.timeLog("single values http call", "json extracted");
 
   if (response.status !== 200) {
     console.error("single values api: error");
     throw Error(body.message);
   }
 
-  console.timeEnd("single values http call");
+  // console.timeEnd("single values http call");
   // console.log("body", body);
   return body;
 }
@@ -113,7 +115,15 @@ export default function Dashboard(props) {
       .then((res) => {
         //console.time("update react");
 
-        updateQueue(res.response);
+        // when the car/data generator is offline, res.response is going to be null,
+        //  so we need to set variables to a default value that will prevent a TypeError
+        //  when we try reading the properties of an undefined variable
+        if (res.response === null) {
+          // this object can't be null for the graph data, so we'll set it to a faux object
+          updateQueue(fauxQueue);
+        } else {
+          updateQueue(res.response);
+        }
 
         //console.timeEnd("update react");
       })
@@ -126,6 +136,7 @@ export default function Dashboard(props) {
         .then((res) => {
           //console.time("update react");
 
+          // when the car/data generator is offline, res.response is going to be null
           setState({ data: res.response });
 
           //console.timeEnd("update react");

--- a/Frontend/src/Components/Graph/faux-queue.json
+++ b/Frontend/src/Components/Graph/faux-queue.json
@@ -1,0 +1,536 @@
+{
+  "timestamps": [
+    "00:00:00.000"
+  ],
+  "speed": [
+    null
+  ],
+  "driver_eStop": [
+    null
+  ],
+  "external_eStop": [
+    null
+  ],
+  "crash": [
+    null
+  ],
+  "door": [
+    null
+  ],
+  "door_lim_out": [
+    null
+  ],
+  "mcu_check": [
+    null
+  ],
+  "mcu_stat_fdbk": [
+    null
+  ],
+  "mcu_hv_en": [
+    null
+  ],
+  "imd_status": [
+    null
+  ],
+  "mcu_latch": [
+    null
+  ],
+  "state": [
+    null
+  ],
+  "fr_telem": [
+    null
+  ],
+  "fr_out": [
+    null
+  ],
+  "linear_accel_x": [
+    null
+  ],
+  "linear_accel_y": [
+    null
+  ],
+  "linear_accel_z": [
+    null
+  ],
+  "angular_rate_pitch": [
+    null
+  ],
+  "angular_rate_roll": [
+    null
+  ],
+  "angular_rate_yaw": [
+    null
+  ],
+  "motor_temp": [
+    null
+  ],
+  "motor_controller_temp": [
+    null
+  ],
+  "dcdc_temp": [
+    null
+  ],
+  "driverIO_temp": [
+    null
+  ],
+  "mainIO_temp": [
+    null
+  ],
+  "cabin_temp": [
+    null
+  ],
+  "road_temp": [
+    null
+  ],
+  "brake_temp": [
+    null
+  ],
+  "air_temp": [
+    null
+  ],
+  "bl_turn_led_en": [
+    null
+  ],
+  "br_turn_led_en": [
+    null
+  ],
+  "bc_brake_led_en": [
+    null
+  ],
+  "bc_bps_led_en": [
+    null
+  ],
+  "headlights_led_en": [
+    null
+  ],
+  "fl_turn_led_en": [
+    null
+  ],
+  "fr_turn_led_en": [
+    null
+  ],
+  "left_turn": [
+    null
+  ],
+  "right_turn": [
+    null
+  ],
+  "hazards": [
+    null
+  ],
+  "headlights": [
+    null
+  ],
+  "horn_status": [
+    null
+  ],
+  "crz_pwr_mode": [
+    null
+  ],
+  "crz_spd_mode": [
+    null
+  ],
+  "crz_pwr_setpt": [
+    null
+  ],
+  "crz_spd_setpt": [
+    null
+  ],
+  "crz_state": [
+    null
+  ],
+  "eco": [
+    null
+  ],
+  "main_telem": [
+    null
+  ],
+  "brake_status": [
+    null
+  ],
+  "mech_brake_status": [
+    null
+  ],
+  "parking_brake": [
+    null
+  ],
+  "accelerator": [
+    null
+  ],
+  "accelerator_out": [
+    null
+  ],
+  "motor_current": [
+    null
+  ],
+  "motor_power": [
+    null
+  ],
+  "mc_status": [
+    null
+  ],
+  "mppt_can_heartbeat": [
+    null
+  ],
+  "mcc_can_heartbeat": [
+    null
+  ],
+  "bms_can_heartbeat": [
+    null
+  ],
+  "mainIO_heartbeat": [
+    null
+  ],
+  "main_5V_bus": [
+    null
+  ],
+  "main_12V_bus": [
+    null
+  ],
+  "main_vbus": [
+    null
+  ],
+  "main_vbus_current": [
+    null
+  ],
+  "driver_5V_bus": [
+    null
+  ],
+  "driver_12V_bus": [
+    null
+  ],
+  "driver_vbus": [
+    null
+  ],
+  "driver_vbus_current": [
+    null
+  ],
+  "main_power_critical": [
+    null
+  ],
+  "main_power_warning": [
+    null
+  ],
+  "main_power_tc": [
+    null
+  ],
+  "main_power_valid": [
+    null
+  ],
+  "driver_power_critical": [
+    null
+  ],
+  "driver_power_warning": [
+    null
+  ],
+  "driver_power_tc": [
+    null
+  ],
+  "driver_power_valid": [
+    null
+  ],
+  "tstamp_ms": [
+    null
+  ],
+  "tstamp_sc": [
+    null
+  ],
+  "tstamp_mn": [
+    null
+  ],
+  "tstamp_hr": [
+    null
+  ],
+  "mppt_contactor": [
+    null
+  ],
+  "motor_controller_contactor": [
+    null
+  ],
+  "low_contactor": [
+    null
+  ],
+  "dcdc_valid": [
+    null
+  ],
+  "supplemental_valid": [
+    null
+  ],
+  "mppt_mode": [
+    null
+  ],
+  "mppt_current_out": [
+    null
+  ],
+  "string1_temp": [
+    null
+  ],
+  "string2_temp": [
+    null
+  ],
+  "string3_temp": [
+    null
+  ],
+  "string1_V_in": [
+    null
+  ],
+  "string2_V_in": [
+    null
+  ],
+  "string3_V_in": [
+    null
+  ],
+  "string1_I_in": [
+    null
+  ],
+  "string2_I_in": [
+    null
+  ],
+  "string3_I_in": [
+    null
+  ],
+  "pack_temp": [
+    null
+  ],
+  "pack_internal_temp": [
+    null
+  ],
+  "pack_current": [
+    null
+  ],
+  "pack_voltage": [
+    null
+  ],
+  "pack_power": [
+    null
+  ],
+  "supplemental_voltage": [
+    null
+  ],
+  "cell_group1_voltage": [
+    null
+  ],
+  "cell_group2_voltage": [
+    null
+  ],
+  "cell_group3_voltage": [
+    null
+  ],
+  "cell_group4_voltage": [
+    null
+  ],
+  "cell_group5_voltage": [
+    null
+  ],
+  "cell_group6_voltage": [
+    null
+  ],
+  "cell_group7_voltage": [
+    null
+  ],
+  "cell_group8_voltage": [
+    null
+  ],
+  "cell_group9_voltage": [
+    null
+  ],
+  "cell_group10_voltage": [
+    null
+  ],
+  "cell_group11_voltage": [
+    null
+  ],
+  "cell_group12_voltage": [
+    null
+  ],
+  "cell_group13_voltage": [
+    null
+  ],
+  "cell_group14_voltage": [
+    null
+  ],
+  "cell_group15_voltage": [
+    null
+  ],
+  "cell_group16_voltage": [
+    null
+  ],
+  "cell_group17_voltage": [
+    null
+  ],
+  "cell_group18_voltage": [
+    null
+  ],
+  "cell_group19_voltage": [
+    null
+  ],
+  "cell_group20_voltage": [
+    null
+  ],
+  "cell_group21_voltage": [
+    null
+  ],
+  "cell_group22_voltage": [
+    null
+  ],
+  "cell_group23_voltage": [
+    null
+  ],
+  "cell_group24_voltage": [
+    null
+  ],
+  "cell_group25_voltage": [
+    null
+  ],
+  "cell_group26_voltage": [
+    null
+  ],
+  "cell_group27_voltage": [
+    null
+  ],
+  "cell_group28_voltage": [
+    null
+  ],
+  "cell_group29_voltage": [
+    null
+  ],
+  "cell_group30_voltage": [
+    null
+  ],
+  "cell_group31_voltage": [
+    null
+  ],
+  "populated_cells": [
+    null
+  ],
+  "soc": [
+    null
+  ],
+  "est_supplemental_soc": [
+    null
+  ],
+  "soh": [
+    null
+  ],
+  "pack_capacity": [
+    null
+  ],
+  "adaptive_total_capacity": [
+    null
+  ],
+  "bps_fault": [
+    null
+  ],
+  "fan_enable": [
+    null
+  ],
+  "fan_speed": [
+    null
+  ],
+  "voltage_failsafe": [
+    null
+  ],
+  "current_failsafe": [
+    null
+  ],
+  "relay_failsafe": [
+    null
+  ],
+  "cell_balancing_active": [
+    null
+  ],
+  "charge_interlock_failsafe": [
+    null
+  ],
+  "thermistor_b_value_table_invalid": [
+    null
+  ],
+  "input_power_supply_failsafe": [
+    null
+  ],
+  "discharge_limit_enforcement_fault": [
+    null
+  ],
+  "charger_safety_relay_fault": [
+    null
+  ],
+  "internal_hardware_fault": [
+    null
+  ],
+  "internal_heatsink_fault": [
+    null
+  ],
+  "internal_software_fault": [
+    null
+  ],
+  "highest_cell_voltage_too_high_fault": [
+    null
+  ],
+  "lowest_cell_voltage_too_low_fault": [
+    null
+  ],
+  "pack_too_hot_fault": [
+    null
+  ],
+  "internal_communication_fault": [
+    null
+  ],
+  "cell_balancing_stuck_off_fault": [
+    null
+  ],
+  "weak_cell_fault": [
+    null
+  ],
+  "low_cell_voltage_fault": [
+    null
+  ],
+  "open_wiring_fault": [
+    null
+  ],
+  "current_sensor_fault": [
+    null
+  ],
+  "highest_cell_voltage_over_5V_fault": [
+    null
+  ],
+  "cell_asic_fault": [
+    null
+  ],
+  "weak_pack_fault": [
+    null
+  ],
+  "fan_monitor_fault": [
+    null
+  ],
+  "thermistor_fault": [
+    null
+  ],
+  "external_communication_fault": [
+    null
+  ],
+  "redundant_power_supply_fault": [
+    null
+  ],
+  "high_voltage_isolation_fault": [
+    null
+  ],
+  "input_power_supply_fault": [
+    null
+  ],
+  "charge_limit_enforcement_fault": [
+    null
+  ],
+  "pack_resistance": [
+    null
+  ],
+  "bms_input_voltage": [
+    null
+  ],
+  "charge_enable": [
+    null
+  ],
+  "discharge_enable": [
+    null
+  ]
+}

--- a/Frontend/src/CustomScripts/convertData.mjs
+++ b/Frontend/src/CustomScripts/convertData.mjs
@@ -110,4 +110,10 @@ const newFileOutput = {
 // console.log(output)
 writeFileSync("./src/Components/Graph/graph-data.json", JSON.stringify(newFileOutput, null, 2))
 
-// export {}
+// generate the faux queue object for when the car/data generator isn't connected
+let fauxQueue = { timestamps: ['00:00:00.000'] };
+for (const key of Object.keys(SC1DataFormat)) {
+  fauxQueue[key] = [null];
+}
+
+writeFileSync("./src/Components/Graph/faux-queue.json", JSON.stringify(fauxQueue, null, 2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chase-car-dashboard",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chase-car-dashboard",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "hasInstallScript": true,
       "dependencies": {
         "cors": "^2.8.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chase-car-dashboard",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "scripts": {
     "data-generator": "cd DataGenerator && npm start",
     "backend": "cd Backend && npm start",


### PR DESCRIPTION
Right now, this commit fixes the issue where the dashboard will crash with a TypeError when it's started without the data generator (or presumably car) connected. Once you start the data generator, the backend will automatically connect and the dashboard will begin showing data. 

~~However, it still crashes if you try to create a graph, so I need to fix that too (that's why this is a draft PR for now).~~
Edit: You shouldn't get any TypeErrors anymore