### PR TITLE
[SW-434] Data recording with Python backend

### DIFF
--- a/Backend/core/core_api.py
+++ b/Backend/core/core_api.py
@@ -31,9 +31,11 @@ async def get_processed_data(start_time, end_time):
 
     result = await db.query_without_aggregation(all_keys, start_time, end_time)
 
+    result.index = pd.to_datetime(result.index, unit='ms')
+
     # see https://stackoverflow.com/a/63989481
     output = io.BytesIO()
-    writer = pd.ExcelWriter(output, engine='xlsxwriter')
+    writer = pd.ExcelWriter(output, engine='xlsxwriter', datetime_format='MM-DD HH:MM:SS')
     result.to_excel(writer, sheet_name='Sheet1')
 
     writer.close()

--- a/Backend/core/core_api.py
+++ b/Backend/core/core_api.py
@@ -21,16 +21,15 @@ async def single_values():
         return json_data
     return {'response': None}
 
-@router.get("/get_processed_data")
+@router.get("/get-processed-data")
 async def get_processed_data(start_time, end_time):
     all_keys = list(comms.frontend_data.keys())
     all_keys.remove('tstamp_ms')
     all_keys.remove('tstamp_sc')
     all_keys.remove('tstamp_mn')
     all_keys.remove('tstamp_hr')
-    # aggregate_methods = ['first' for key in all_keys]
 
-    result = await db.query_without_aggregation(all_keys, start_time, end_time)#, aggregate_methods)
+    result = await db.query_without_aggregation(all_keys, start_time, end_time)
 
     # see https://stackoverflow.com/a/63989481
     output = io.BytesIO()

--- a/Backend/core/db.py
+++ b/Backend/core/db.py
@@ -9,7 +9,7 @@ r = redis.StrictRedis(host=config.REDIS_URL, port=config.REDIS_PORT, db=config.R
 def insert_data(data_dict):
     # Get the timestamp from the dictionary
     timestamp = datetime.utcnow().replace(
-        hour=(data_dict['tstamp_hr'] + 6) % 24,
+        hour=(data_dict['tstamp_hr'] + 1) % 24,
         minute=data_dict['tstamp_mn'],
         second=data_dict['tstamp_sc'],
         microsecond=data_dict['tstamp_ms']

--- a/Backend/setup.py
+++ b/Backend/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='chase-car-dashboard-backend',
-    version='5.0.0',
+    version='5.1.0',
     packages=['core', 'framework', 'components'],
     url='badgersolarracing.org',
     license='',

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chase-car-dashboard-frontend",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chase-car-dashboard-frontend",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "private": true,
   "proxy": "http://localhost:4001",
   "dependencies": {

--- a/Frontend/src/Components/Dashboard/DataRecordingControl.js
+++ b/Frontend/src/Components/Dashboard/DataRecordingControl.js
@@ -78,8 +78,8 @@ export default function DataRecordingControl(props) {
     const endTimeChanged = (event) => setEndTime(event.target.value);
 
     const triggerDownload = () => {
-        const startTimeUnix = Math.round(new Date(startTime).getTime()/1000);
-        const endTimeUnix = Math.round(new Date(endTime).getTime()/1000);
+        const startTimeUnix = Math.round(new Date(startTime).getTime());
+        const endTimeUnix = Math.round(new Date(endTime).getTime());
 
         window.open('http://localhost:4001'
             + ROUTES.GET_PROCESSED_DATA

--- a/Frontend/src/Components/Shared/misc-constants.js
+++ b/Frontend/src/Components/Shared/misc-constants.js
@@ -7,9 +7,5 @@ export const ROUTES = {
     UPDATE_GRAPHS_METADATA: "/needed-graphs-metadata",
     GET_SINGLE_VALUES: "/single-values",
     GET_GRAPH_DATA: "/graph-data",
-    GET_SESSION_LIST: "/sessions-list",
-    CREATE_RECORDING_SESSION: "/create-recording-session",
-    SET_RECORDING_SESSION: "/current-recording-session",
-    SET_RECORD: "/record-data",
-    PROCESS_RECORDED_DATA: "/process-recorded-data"
+    GET_PROCESSED_DATA: "/get-processed-data",
 }


### PR DESCRIPTION
Currently, the JavaScript frontend and backend use a stateful API design where the frontend tells the backend to start recording. Since one of the goals of the Python backend is to make the API design stateless (as far as I understand), we'll have to rethink how the API works for data recording too. This PR tracks code changes for SW-434. 

Known issues:

- [x] Excel file contains raw Unix timestamp in first column. This should be converted to a date/time that Excel understands (currently it appears as a scientific notation value, which isn't useful).
- [x] The frontend needs to be updated to handle the new API call

Confluence page about API docs: https://badgerloop.atlassian.net/wiki/spaces/EL/pages/356646927/Engineering+dashboard+API+Documentation

UI design:
<img width="788" alt="image" src="https://github.com/badgerloop-software/chase-car-dashboard/assets/17338790/2f7dc5bc-caab-4122-ae5c-8810a4472f94">

Output: 
<img width="1435" alt="image" src="https://github.com/badgerloop-software/chase-car-dashboard/assets/17338790/ce4b9f33-6f7e-44c2-b4a8-8868804e7f83">

