### PR TITLE
Add 3rd party file_sync dep to backend deps

### DIFF
--- a/Backend/setup.py
+++ b/Backend/setup.py
@@ -9,5 +9,5 @@ setup(
     author='Badger Solar Racing Software Team',
     author_email='',
     description='',
-    install_requires=['uvicorn','fastapi','redis', 'numpy', 'XlsxWriter', 'pandas', 'aiohttp']
+    install_requires=['uvicorn','fastapi','redis', 'requests', 'numpy', 'XlsxWriter', 'pandas', 'aiohttp']
 )


### PR DESCRIPTION
file_sync depends on requests, but if you run the backend in a fresh virtualenv, `pip install .` doesn't install requests. 

Not sure this PR is the best way to solve the issue, but file_sync doesn't have its own setup.py. Maybe it should since the driver IO end doesn't have a setup.py either?