### PR TITLE
Fix: stop GPS data replay after finishing CSV (prevent looping)

### DIFF
--- a/DataReplayer/src/server.js
+++ b/DataReplayer/src/server.js
@@ -265,7 +265,7 @@ function startSending() {
     console.log('Starting to send data packets...');
     console.log(`Sending at ~31Hz (32ms intervals) to localhost:${PORT}`);
     
-    setInterval(() => {
+    const sendInterval = setInterval(() => {
         if (csvData.length === 0) return;
         
         const currentRow = csvData[currentIndex];
@@ -278,7 +278,21 @@ function startSending() {
         });
         
         // Move to next row, loop back to start when done
-        currentIndex = (currentIndex + 1) % csvData.length;
+        currentIndex++;
+
+        // Log progress occasionally
+        if (currentIndex % 100 === 0) {
+        console.log(`Sent ${currentIndex} packets, timestamp: ${currentRow.Var1 || 'N/A'}`);
+        }
+
+        // Stop when finished
+        if (currentIndex >= csvData.length) {
+        console.log('All data packets sent. Stopping replay.');
+        clearInterval(sendInterval);
+        client.close();
+        process.exit(0);
+        } 
+
         
         // Log progress occasionally
         if (currentIndex % 100 === 0) {


### PR DESCRIPTION
This branch fixed the error that when the program finishes reading the csv file, it will jump back the the beginning and not terminates. Now it stops and prevents over counting, so we can verify whether the program accurately counts the laps.